### PR TITLE
Do NOT patch up INST_ARCHLIB

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension Net::Z3950::SimpleServer
 
+IN PROGRESS
+	* Revert ZOOM-31, which prevented installation from
+	  working. See https://folio-org.atlassian.net/browse/ZF-103
+
 1.27  Fri  5 Jul 2024 20:35:58 BST
 	* Rework configuration to use Debian's yaz-config when
 	  pkg-config is absent. Fixes ZOOM-30.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -63,5 +63,9 @@ __EOT__
 
 # When running on MacOS Monterey 12.7.5, "make test" fails with
 # Can't load 'blib/arch/auto/Net/Z3950/SimpleServer/SimpleServer.bundle' for module Net::Z3950::SimpleServer [...] (relative path not allowed in hardened program)
-# We prevent this by overriding the target with an absolute path:
-sub MY::postamble { 'INST_ARCHLIB = `pwd`/blib/arch' }
+# We can prevent this by overriding the target with an absolute path:
+#
+# HOWEVER, doing so causes the "make install" phase to fail: see
+# https://folio-org.atlassian.net/browse/ZF-103
+# So until we figure out something better, we'll just comment this out.
+#sub MY::postamble { 'INST_ARCHLIB = `pwd`/blib/arch' }


### PR DESCRIPTION
This change made tests work on MacOS, but at the expense of preventing installation on any platform, including Docker builds.

See https://folio-org.atlassian.net/browse/ZF-103

Reverts ZOOM-31.